### PR TITLE
UserList Class that holds a hashset with current users

### DIFF
--- a/IRCConnectionTest/UserList.cs
+++ b/IRCConnectionTest/UserList.cs
@@ -41,12 +41,19 @@ namespace IRCConnectionTest
                 UsrList[channel].Add(userName);
         }
 
-        public static HashSet<string> GetUserList(string channel)
+        public static IEnumerable<string> GetUserList(string channel)
         {
             if (!UsrList.ContainsKey(channel))
                 UsrList.Add(channel, new HashSet<string>());
 
-            return UsrList[channel];
+            return new HashSet<string>(UsrList[channel]);
+        }
+
+        public static ISet<string> GetUserListAsSet(string channel) {
+            if(!UsrList.ContainsKey(channel))
+                UsrList.Add(channel, new HashSet<string>());
+
+            return new HashSet<string>(UsrList[channel]);
         }
     }
 }


### PR DESCRIPTION
To make the UserList work you need to add this line in your App.cs after the connection is established:

``` c#
System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(UserList).TypeHandle);
```
