### PR TITLE
Feature/user awards

### DIFF
--- a/iBot/Core/Settings/GeneralSettings.cs
+++ b/iBot/Core/Settings/GeneralSettings.cs
@@ -1,0 +1,20 @@
+﻿using System.Configuration;
+using Newtonsoft.Json;
+
+namespace IBot.Core.Settings
+{
+    internal class GeneralSettings : SettingsBase
+    {
+        [JsonProperty("user_message_spam_threshold")]
+        public int UserMessageSpamThreshold { get; set; } = 6;
+
+        [JsonProperty("user_message_spam_interval")]
+        public int UserMessageSpamInterval { get; set; } = 10;
+
+        [JsonProperty("user_emote_spam_threshold")]
+        public int UserEmoteSpamThreshold { get; set; } = 6;
+
+        [JsonProperty("user_emote_spam_interval")]
+        public int UserEmoteSpamInterval { get; set; } = 10;
+    }
+}

--- a/iBot/Core/Settings/GeneralSettings.cs
+++ b/iBot/Core/Settings/GeneralSettings.cs
@@ -16,5 +16,11 @@ namespace IBot.Core.Settings
 
         [JsonProperty("user_emote_spam_interval")]
         public int UserEmoteSpamInterval { get; set; } = 10;
+
+        [JsonProperty("user_emote_spam_message_percentage")]
+        public double UserEmoteSpamMessagePercentage { get; set; } = 35.0d;
+
+        [JsonProperty("user_emote_spam_message_threshold")]
+        public int UserEmoteSpamMessageThreshold { get; set; } = 6;
     }
 }

--- a/iBot/Events/Args/Users/UserEventArgs.cs
+++ b/iBot/Events/Args/Users/UserEventArgs.cs
@@ -20,6 +20,9 @@ namespace IBot.Events.Args.Users
     {
         Join,
         Part,
-        Spam
+        Spam,
+        SpamEnd,
+        EmojiSpam,
+        EmojiSpamEnd
     }
 }

--- a/iBot/Events/Args/Users/UserEventArgs.cs
+++ b/iBot/Events/Args/Users/UserEventArgs.cs
@@ -19,6 +19,7 @@ namespace IBot.Events.Args.Users
     internal enum UserEventType
     {
         Join,
-        Part
+        Part,
+        Spam
     }
 }

--- a/iBot/Events/UserEventManager.cs
+++ b/iBot/Events/UserEventManager.cs
@@ -64,8 +64,8 @@ namespace IBot.Events
                              settings.UserEmoteSpamInterval,
                              eArgs => UserEmojiSpamEvent?.Invoke(null, new UserEventArgs(eArgs.UserName, eArgs.Channel, UserEventType.EmojiSpam)),
                              eArgs => UserEmojiSpamEndEvent?.Invoke(null, new UserEventArgs(eArgs.UserName, eArgs.Channel, UserEventType.EmojiSpamEnd)),
-                             eArgs => EmoteTools.EmotePercentageOfMessage(eArgs.Message, eArgs.Tags.Emotes) >= 35.0d,
-                             eArgs => EmoteTools.ParseEmotes(eArgs.Tags.Emotes).Count >= 6);
+                             eArgs => EmoteTools.EmotePercentageOfMessage(eArgs.Message, eArgs.Tags.Emotes) >= settings.UserEmoteSpamMessagePercentage,
+                             eArgs => EmoteTools.ParseEmotes(eArgs.Tags.Emotes).Count >= settings.UserEmoteSpamMessageThreshold);
         }
 
         private static void CheckForSpam(object sender, UserPublicMessageEventArgs eventArgs)

--- a/iBot/Events/UserEventManager.cs
+++ b/iBot/Events/UserEventManager.cs
@@ -64,7 +64,8 @@ namespace IBot.Events
                              settings.UserEmoteSpamInterval,
                              eArgs => UserEmojiSpamEvent?.Invoke(null, new UserEventArgs(eArgs.UserName, eArgs.Channel, UserEventType.EmojiSpam)),
                              eArgs => UserEmojiSpamEndEvent?.Invoke(null, new UserEventArgs(eArgs.UserName, eArgs.Channel, UserEventType.EmojiSpamEnd)),
-                             eArgs => EmoteTools.ParseEmotes(eArgs.Tags.Emotes).Count >= 1);
+                             eArgs => EmoteTools.EmotePercentageOfMessage(eArgs.Message, eArgs.Tags.Emotes) >= 35.0d,
+                             eArgs => EmoteTools.ParseEmotes(eArgs.Tags.Emotes).Count >= 6);
         }
 
         private static void CheckForSpam(object sender, UserPublicMessageEventArgs eventArgs)

--- a/iBot/Models/Emote.cs
+++ b/iBot/Models/Emote.cs
@@ -12,5 +12,6 @@
         public int Id { get; }
         public int Start { get; }
         public int End { get; }
+        public int Length => End - Start;
     }
 }

--- a/iBot/Models/Emote.cs
+++ b/iBot/Models/Emote.cs
@@ -1,0 +1,16 @@
+﻿namespace IBot.Models
+{
+    internal class Emote
+    {
+        public Emote(int id, int start, int end)
+        {
+            Id = id;
+            Start = start;
+            End = end;
+        }
+
+        public int Id { get; }
+        public int Start { get; }
+        public int End { get; }
+    }
+}

--- a/iBot/Plugins/UserAwards/Award.cs
+++ b/iBot/Plugins/UserAwards/Award.cs
@@ -1,0 +1,52 @@
+﻿using System.Linq;
+using IBot.Core;
+
+namespace IBot.Plugins.UserAwards
+{
+    internal class Award
+    {
+        public AwardType Type { get; private set; }
+        public double Multiplier { get; private set; }
+        public double Value { get; private set; }
+        public double TotalValue => Multiplier * Value;
+
+        public Award(AwardType type)
+        {
+            Type = type;
+            Multiplier = 1;
+
+            var settings = SettingsManager.GetSettings<AwardSettings>();
+
+            // get a list of all properties for AwardSettings
+            // get a list of all attributes for each Property
+            // if we found a property with the same AwardType as this one, set Value to its value
+            // otherwise continue
+            foreach (var property in typeof(AwardSettings).GetProperties())
+            {
+                foreach (var attribute in property.GetCustomAttributes(false).OfType<AwardTypeAttribute>())
+                {
+                    if (attribute.Type != type)
+                        continue;
+
+                    Value = (double) property.GetValue(settings);
+                    return;
+                }
+            }
+
+            // we only arrive here if we haven't found any Property with
+            // [AwardType(type)]
+            // in the settings
+            Value = 0.0d;
+        }
+
+        public void Add(double increment)
+        {
+            Multiplier += increment;
+        }
+
+        public void Remove(double decrement)
+        {
+            Multiplier -= decrement;
+        }
+    }
+}

--- a/iBot/Plugins/UserAwards/AwardSettings.cs
+++ b/iBot/Plugins/UserAwards/AwardSettings.cs
@@ -1,0 +1,44 @@
+﻿using System.Configuration;
+using Newtonsoft.Json;
+
+namespace IBot.Plugins.UserAwards
+{
+    public class AwardSettings : SettingsBase
+    {
+        [AwardType(AwardType.JoinedChannel)]
+        [JsonProperty(PropertyName = "value_joined_channel")]
+        public double JoinedChannelValue { get; set; } = 5;
+
+        [AwardType(AwardType.Follows)]
+        [JsonProperty(PropertyName = "value_follows")]
+        public double FollowsValue { get; set; } = 5;
+
+        [AwardType(AwardType.Subscribed)]
+        [JsonProperty(PropertyName = "value_subscribed")]
+        public double SubscribedValue { get; set; } = 10;
+
+        [AwardType(AwardType.AccountAge)]
+        [JsonProperty(PropertyName = "value_account_age")]
+        public double AccountAgeValue { get; set; } = 0.2;
+
+        [AwardType(AwardType.Chatter)]
+        [JsonProperty(PropertyName = "value_chatter")]
+        public double ChatterValue { get; set; } = 5;
+
+        [AwardType(AwardType.ChatterCommander)]
+        [JsonProperty(PropertyName = "value_chatter_commands")]
+        public double ChatterCommandsValue { get; set; } = -1;
+
+        [AwardType(AwardType.ChatterSpammer)]
+        [JsonProperty(PropertyName = "value_chatter_spammer")]
+        public double ChatterSpammerValue { get; set; } = -10;
+
+        [AwardType(AwardType.ChatterEmoji)]
+        [JsonProperty(PropertyName = "value_chatter_emoji")]
+        public double ChatterEmojiValue { get; set; } = -10;
+
+        [AwardType(AwardType.OftenCensored)]
+        [JsonProperty(PropertyName = "value_often_censored")]
+        public double OftenCensoredValue { get; set; } = -10;
+    }
+}

--- a/iBot/Plugins/UserAwards/AwardType.cs
+++ b/iBot/Plugins/UserAwards/AwardType.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace IBot.Plugins.UserAwards
+{
+    internal enum AwardType : Int32
+    {
+        [Description("Joined Channel")]
+        JoinedChannel,
+
+        [Description("Follows Channel")]
+        Follows,
+
+        [Description("Subscribed to Channel")]
+        Subscribed,
+
+        [Description("Account Age")]
+        AccountAge,
+
+        [Description("Chatter")]
+        Chatter,
+
+        [Description("Command abuser")]
+        ChatterCommander,
+
+        [Description("Spammer")]
+        ChatterSpammer,
+
+        [Description("Emojii Abuser")]
+        ChatterEmoji,
+
+        [Description("Often Censored")]
+        OftenCensored,
+    }
+}

--- a/iBot/Plugins/UserAwards/AwardTypeAttribute.cs
+++ b/iBot/Plugins/UserAwards/AwardTypeAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace IBot.Plugins.UserAwards
+{
+    internal class AwardTypeAttribute : Attribute
+    {
+        public AwardType Type { get; set; }
+
+        public AwardTypeAttribute(AwardType type)
+        {
+            Type = type;
+        }
+    }
+}

--- a/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
+++ b/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
@@ -33,6 +33,8 @@ namespace IBot.Plugins.UserAwards
             UserList.UserListUpdated += OnUserListUpdated;
             UserEventManager.UserSpamEvent += OnUserSpam;
             UserEventManager.UserSpamEndEvent += OnUserSpamEnd;
+            UserEventManager.UserEmojiSpamEvent += OnUserEmojiSpam;
+            UserEventManager.UserEmojiSpamEndEvent += OnUserEmojiSpamEnd;
         }
 
         private void UnregisterEvents()
@@ -45,6 +47,10 @@ namespace IBot.Plugins.UserAwards
         private void OnUserSpam(object sender, UserEventArgs eventArgs) => AddAward(eventArgs.UserName, new Award(AwardType.ChatterSpammer));
 
         private void OnUserSpamEnd(object sender, UserEventArgs eventArgs) => RemoveAward(eventArgs.UserName, AwardType.ChatterSpammer);
+
+        private void OnUserEmojiSpam(object sender, UserEventArgs userEventArgs) => AddAward(userEventArgs.UserName, new Award(AwardType.ChatterEmoji));
+
+        private void OnUserEmojiSpamEnd(object sender, UserEventArgs userEventArgs) => RemoveAward(userEventArgs.UserName, AwardType.ChatterSpammer);
 
         private void OnUserListUpdated(object sender, EventArgs eventArgs)
         {

--- a/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
+++ b/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using IBot.Core;
+using IBot.Events;
+using IBot.Events.Args.Users;
+using IBot.Models;
+using Timer = System.Timers.Timer;
+
+namespace IBot.Plugins.UserAwards
+{
+    internal class UserAwardsPlugin : IPlugin
+    {
+        private static readonly Dictionary<string, List<Award>> UserAwards = new Dictionary<string, List<Award>>();
+
+        public string PluginName => "User Awards Plugin";
+
+        public void Init() => Start();
+
+        public void Start()
+        {
+            var settings = SettingsManager.GetSettings<AwardSettings>();
+
+            RegisterEvents();
+        }
+
+        public void Stop()
+        {
+            UnregisterEvents();
+        }
+
+        private void RegisterEvents()
+        {
+            UserList.UserListUpdated += OnUserListUpdated;
+            UserEventManager.UserSpamEvent += OnUserSpam;
+            UserEventManager.UserSpamEndEvent += OnUserSpamEnd;
+        }
+
+        private void UnregisterEvents()
+        {
+            UserList.UserListUpdated -= OnUserListUpdated;
+            UserEventManager.UserSpamEvent -= OnUserSpam;
+            UserEventManager.UserSpamEndEvent -= OnUserSpamEnd;
+        }
+
+        private void OnUserSpam(object sender, UserEventArgs eventArgs) => AddAward(eventArgs.UserName, new Award(AwardType.ChatterSpammer));
+
+        private void OnUserSpamEnd(object sender, UserEventArgs eventArgs) => RemoveAward(eventArgs.UserName, AwardType.ChatterSpammer);
+
+        private void OnUserListUpdated(object sender, EventArgs eventArgs)
+        {
+            var list = UserList.GetUserList(SettingsManager.GetOwnerChannel());
+
+            foreach (var user in list)
+            {
+                AddAward(username: user.Username,
+                         award: new Award(AwardType.JoinedChannel),
+                         incrementIfAvailable: false);
+
+                if (PermissionManager.GetRights(user).HasFlag(Rights.Follower))
+                    AddAward(username: user.Username,
+                             award: new Award(AwardType.Follows),
+                             incrementIfAvailable: false);
+
+                if (PermissionManager.GetRights(user).HasFlag(Rights.Subscriber))
+                    AddAward(username: user.Username,
+                             award: new Award(AwardType.Subscribed),
+                             incrementIfAvailable: false);
+            }
+        }
+
+        private void AddAward(string username, Award award, bool incrementIfAvailable = true, double incrementValue = 1.0d)
+        {
+            if (!UserAwards.ContainsKey(username))
+                UserAwards.Add(username, new List<Award>());
+
+            lock (UserAwards[username])
+            {
+                if (UserAwards[username].Any(a => a.Type == award.Type))
+                {
+                    if (incrementIfAvailable)
+                    {
+                        UserAwards[username].First(a => a.Type == award.Type).Add(incrementValue);
+                    }
+
+                    return;
+                }
+
+                UserAwards[username].Add(award);
+            }
+        }
+
+        private void RemoveAward(string username, AwardType type)
+        {
+            if (!UserAwards.ContainsKey(username))
+                UserAwards.Add(username, new List<Award>());
+
+            lock (UserAwards[username])
+            {
+                UserAwards[username].RemoveAll(a => a.Type == type);
+            }
+        }
+
+        public static IEnumerable<Award> GetAwards(User user) => GetAwards(user.Username);
+
+        public static IEnumerable<Award> GetAwards(string username)
+        {
+            if (UserAwards.ContainsKey(username))
+            {
+                var retVal = new Award[UserAwards[username].Count];
+                UserAwards[username].CopyTo(retVal);
+
+                return retVal.ToList();
+            }
+
+            return new List<Award>();
+        }
+
+        public static double GetUserPoints(string username) => UserAwards[username].Sum(award => award.TotalValue);
+    }
+}

--- a/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
+++ b/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
@@ -90,14 +90,14 @@ namespace IBot.Plugins.UserAwards
                         var existingAward = UserAwards[username].First(a => a.Type == award.Type);
                         existingAward.Add(incrementValue);
 
-                        Logger.Debug("user {0} received increment for award {1}, now at {2}", username, award.Type, existingAward.TotalValue);
+                        Logger.Info("user {0} received increment for award {1}, now at {2}", username, award.Type, existingAward.TotalValue);
                     }
 
                     return;
                 }
 
                 UserAwards[username].Add(award);
-                Logger.Debug("user {0} received award {1}, now at {2}", username, award.Type, award.TotalValue);
+                Logger.Info("user {0} received award {1}, now at {2}", username, award.Type, award.TotalValue);
             }
         }
 
@@ -109,6 +109,7 @@ namespace IBot.Plugins.UserAwards
             lock (UserAwards[username])
             {
                 UserAwards[username].RemoveAll(a => a.Type == type);
+                Logger.Info("user {0} lost award {1}", username, type);
             }
         }
 

--- a/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
+++ b/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using IBot.Core;
 using IBot.Events;
 using IBot.Events.Args.Users;
 using IBot.Models;
-using Timer = System.Timers.Timer;
 
 namespace IBot.Plugins.UserAwards
 {

--- a/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
+++ b/iBot/Plugins/UserAwards/UserAwardsPlugin.cs
@@ -5,11 +5,13 @@ using IBot.Core;
 using IBot.Events;
 using IBot.Events.Args.Users;
 using IBot.Models;
+using NLog;
 
 namespace IBot.Plugins.UserAwards
 {
     internal class UserAwardsPlugin : IPlugin
     {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         private static readonly Dictionary<string, List<Award>> UserAwards = new Dictionary<string, List<Award>>();
 
         public string PluginName => "User Awards Plugin";
@@ -85,13 +87,17 @@ namespace IBot.Plugins.UserAwards
                 {
                     if (incrementIfAvailable)
                     {
-                        UserAwards[username].First(a => a.Type == award.Type).Add(incrementValue);
+                        var existingAward = UserAwards[username].First(a => a.Type == award.Type);
+                        existingAward.Add(incrementValue);
+
+                        Logger.Debug("user {0} received increment for award {1}, now at {2}", username, award.Type, existingAward.TotalValue);
                     }
 
                     return;
                 }
 
                 UserAwards[username].Add(award);
+                Logger.Debug("user {0} received award {1}, now at {2}", username, award.Type, award.TotalValue);
             }
         }
 

--- a/iBot/Tools/EmoteTools.cs
+++ b/iBot/Tools/EmoteTools.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using IBot.Models;
+
+namespace Tools
+{
+    internal static class EmoteTools
+    {
+        public static List<Emote> ParseEmotes(string tagEmotes)
+        {
+            if (string.IsNullOrWhiteSpace(tagEmotes))
+                return new List<Emote>();
+
+            var emotes = tagEmotes.Split('/');
+            var list = new List<Emote>();
+
+            foreach (var emote in emotes)
+            {
+                var parts = emote.Split(',');
+                var lastId = 0;
+
+                foreach (var part in parts)
+                {
+                    string[] startEnd;
+                    int id;
+                    if (part.Contains(":"))
+                    {
+                        var elements = part.Split(':');
+                        id = Convert.ToInt32(elements[0]);
+                        startEnd = elements[1].Split('-');
+                        lastId = id;
+                    }
+                    else
+                    {
+                        id = Convert.ToInt32(lastId);
+                        startEnd = part.Split('-');
+                    }
+                    var start = Convert.ToInt32(startEnd[0]);
+                    var end = Convert.ToInt32(startEnd[1]);
+                    list.Add(new Emote(id, start, end));
+                }
+            }
+
+            return list;
+        }
+    }
+}

--- a/iBot/Tools/EmoteTools.cs
+++ b/iBot/Tools/EmoteTools.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using IBot.Models;
 
 namespace Tools
@@ -42,6 +44,39 @@ namespace Tools
             }
 
             return list;
+        }
+
+        public static double EmotePercentageOfMessage(string message, string emoteTags)
+        {
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(emoteTags))
+                return 0.0d;
+
+            var builder = new StringBuilder();
+
+            var emotes = ParseEmotes(emoteTags).OrderBy(e => e.Start).ToList();
+
+            var messageIndex = 0;
+            for (int emoteIndex = 0; emoteIndex < emotes.Count(); emoteIndex++)
+            {
+                var emote = emotes[emoteIndex];
+                builder.Append(message.Substring(messageIndex, emote.Start - messageIndex));
+
+                // unicode replacement character, we use this char to mark an emote
+                builder.Append("\ufffd\ufffd");
+
+                messageIndex = emote.End + 1;
+            }
+
+            var filteredMessage = builder.ToString();
+            var noEmoteMessage = filteredMessage.Replace("\ufffd", "");
+
+            var fullLength = filteredMessage.Length;
+            var noEmoteLength = noEmoteMessage.Length;
+
+            var textPercentage = (100.0 / fullLength) * noEmoteLength;
+            var emotePercentage = 100.0 - textPercentage;
+
+            return emotePercentage;
         }
     }
 }

--- a/iBot/TwitchAPI/Models/Emoticon.cs
+++ b/iBot/TwitchAPI/Models/Emoticon.cs
@@ -9,14 +9,5 @@ namespace IBot.TwitchAPI.Models
 
         [JsonProperty("images")]
         public Image[] Images { get; set; }
-
-        [JsonProperty("id")]
-        public int Id { get; set; }
-
-        [JsonProperty("code")]
-        public string Code { get; set; }
-
-        [JsonProperty("emoticon_set")]
-        public int EmoticonSet { get; set; }
     }
 }

--- a/iBot/TwitchAPI/Models/Image.cs
+++ b/iBot/TwitchAPI/Models/Image.cs
@@ -5,13 +5,13 @@ namespace IBot.TwitchAPI.Models
     public class Image
     {
         [JsonProperty("emoticon_set")]
-        public int EmoticonSet { get; set; }
+        public int? EmoticonSet { get; set; }
 
         [JsonProperty("height")]
-        public int Height { get; set; }
+        public int? Height { get; set; }
 
         [JsonProperty("width")]
-        public int Width { get; set; }
+        public int? Width { get; set; }
 
         [JsonProperty("url")]
         public string Url { get; set; }

--- a/iBot/iBot.csproj
+++ b/iBot/iBot.csproj
@@ -188,6 +188,11 @@
     <Compile Include="Plugins\Poll\PollOption.cs" />
     <Compile Include="Plugins\Poll\PollPlugin.cs" />
     <Compile Include="Plugins\Poll\PollResult.cs" />
+    <Compile Include="Plugins\UserAwards\Award.cs" />
+    <Compile Include="Plugins\UserAwards\AwardSettings.cs" />
+    <Compile Include="Plugins\UserAwards\AwardType.cs" />
+    <Compile Include="Plugins\UserAwards\AwardTypeAttribute.cs" />
+    <Compile Include="Plugins\UserAwards\UserAwardsPlugin.cs" />
     <Compile Include="Plugins\UserPoints\PointSettings.cs" />
     <Compile Include="Plugins\UserPoints\UserPointPlugin.cs" />
     <Compile Include="Program.cs" />

--- a/iBot/iBot.csproj
+++ b/iBot/iBot.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Core\Rights.cs" />
     <Compile Include="Core\SettingsManager.cs" />
     <Compile Include="Core\Settings\ConnectionSettings.cs" />
+    <Compile Include="Core\Settings\GeneralSettings.cs" />
     <Compile Include="Core\Settings\SettingsHelper.cs" />
     <Compile Include="Events\Args\Connections\ConnectionEventArgs.cs" />
     <Compile Include="Events\Args\Connections\ConnectionUnexpectedCloseEventArgs.cs" />

--- a/iBot/iBot.csproj
+++ b/iBot/iBot.csproj
@@ -133,6 +133,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Poll.resx</DependentUpon>
     </Compile>
+    <Compile Include="Models\Emote.cs" />
     <Compile Include="Plugins\Poll\EventArgs\PollChangedEventArgs.cs" />
     <Compile Include="Plugins\Poll\EventArgs\PollCreatedEventArgs.cs" />
     <Compile Include="Facades\Plugins\Poll\Option.cs" />
@@ -227,6 +228,7 @@
     <Compile Include="TmiApi\TmiUriProvider.cs" />
     <Compile Include="Models\User.cs" />
     <Compile Include="Core\UserList.cs" />
+    <Compile Include="Tools\EmoteTools.cs" />
     <Compile Include="TwitchAPI\Models\Admin.cs" />
     <Compile Include="TwitchAPI\Models\Authorization.cs" />
     <Compile Include="TwitchAPI\Models\Badge.cs" />


### PR DESCRIPTION
**Basis** for ActivityScore #43  
This does not solve the issue

This is my proposed basis for the ActivityScore Plugin.
Currently it hooks into the new Spam / SpamEnd events (same for emotes) to give out "awards" to users.

**Awards**

Awards represent things that a user has achieved, good or bad.  
An `Award` has a type, value, and multiplier.
`Value` is the base value of the Award and should not be changed.
`Multiplier` shows how often the user has gained this award, everytime increasing the total Value.
`TotalValue` gives you direct access to `Value * Multiplier`

You can retrieve a Users awards by calling `UserAwardsPlugin.GetAwards`, and the calculated total of the awards directly with `UserAwardsPlugin.GetPoints`.  

To fully use this, we probably need more awards that we can give out, but i'm not sure how i can implement some of these
