### PR TITLE
Fix crash when starting without Config

### DIFF
--- a/iBot-GUI/Pages/Start/StartPage.xaml.cs
+++ b/iBot-GUI/Pages/Start/StartPage.xaml.cs
@@ -45,22 +45,28 @@ namespace iBot_GUI.Pages.Start
 
         private void UserListTimerOnTick(object sender, EventArgs eventArgs)
         {
-            if (Dispatcher.CheckAccess())
+            Action action = () =>
             {
+                var channel = SettingsManager.GetConnectionSettings()
+                                             ?.Value
+                                             ?.ChannelList
+                                             ?.FirstOrDefault();
+                if (channel == null)
+                    return;
+
                 ChatterList.ItemsSource =
-                    ChatterList.ItemsSource =
-                        UserList.GetUsers(SettingsManager.GetConnectionSettings().Value.ChannelList.First())
+                    UserList.GetUsers(channel)
                             .Select(user => user.Name)
                             .ToList();
+            };
+
+            if (Dispatcher.CheckAccess())
+            {
+                action.Invoke();
             }
             else
             {
-                Dispatcher.Invoke(
-                    () =>
-                        ChatterList.ItemsSource =
-                            UserList.GetUsers(SettingsManager.GetConnectionSettings().Value.ChannelList.First())
-                                .Select(user => user.Name)
-                                .ToList());
+                Dispatcher.Invoke(action);
             }
 
             ChatterList.SelectedItem = null;


### PR DESCRIPTION
When updating the `ChatterList` in the `StartPage`, we access the `ChannelList` property without checking for `null` - possibly resulting in a call of `First()` on an empty list.
This would cause a crash.