### PR TITLE
Enhancement: Refactor settings menu

### DIFF
--- a/iBot-GUI/Controls/SettingsControl.xaml.cs
+++ b/iBot-GUI/Controls/SettingsControl.xaml.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using System.Collections;
-using System.ComponentModel;
-using System.Globalization;
-using System.Linq;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using iBot_GUI.Pages.Settings;
-using iBot_GUI.Resources;
-using IBot.Facades.Core;
+using iBot_GUI.Utilities;
 using IBot.Facades.Core.Settings;
 
 namespace iBot_GUI.Controls
@@ -32,7 +24,8 @@ namespace iBot_GUI.Controls
             InitializeComponent();
         }
 
-        private static void PropertyChangedCallback(DependencyObject dpObject, DependencyPropertyChangedEventArgs eventArgs)
+        private static void PropertyChangedCallback(DependencyObject dpObject,
+                                                    DependencyPropertyChangedEventArgs eventArgs)
         {
             if (!(dpObject is SettingsControl))
                 return;
@@ -47,161 +40,9 @@ namespace iBot_GUI.Controls
         private void MakeScaffolding()
         {
             MainStack.Children.Clear();
-            MainStack.Children.Add(MakeScaffolding(Settings));
-        }
 
-        private UIElement MakeScaffolding<T>(T settings)
-        {
-            var stack = new StackPanel();
-
-            var type = settings.GetType();
-
-            var props = type.GetProperties();
-
-            foreach (var prop in props)
-            {
-                var element = new DockPanel();
-
-                var propType = prop.PropertyType;
-                var value = prop.GetValue(settings);
-
-                var settingsDescriptionIdentifier = Attribute.GetCustomAttributes(prop)
-                                                             .OfType<DescriptionAttribute>()
-                                                             .FirstOrDefault()
-                                                            ?.Description;
-
-                var description = string.IsNullOrWhiteSpace(settingsDescriptionIdentifier)
-                                      ? ""
-                                      : SettingsDescriptions.ResourceManager.GetString(settingsDescriptionIdentifier);
-
-                if (propType.IsValueType
-                    || value is string
-                    || value is IList
-                    || value is IDictionary)
-                {
-                    UIElement valueElement;
-
-                    var label = new Label
-                    {
-                        Content = prop.Name,
-                        ToolTip = description
-                    };
-
-                    var binding = new Binding(prop.Name)
-                    {
-                        Source = settings,
-                        UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
-                        Mode = BindingMode.TwoWay,
-                        Delay = 250
-                    };
-
-                    if (value is char || value is string)
-                    {
-                        var box = new TextBox { Text = value.ToString() };
-                        box.SetBinding(TextBox.TextProperty, binding);
-
-                        valueElement = box;
-                    }
-                    else if (value is bool)
-                    {
-                        var box = new CheckBox { IsChecked = (bool) value };
-                        box.SetBinding(CheckBox.IsCheckedProperty, binding);
-
-                        valueElement = box;
-                    }
-                    else if (value is short || value is int || value is long || value is ushort || value is uint || value is ulong)
-                    {
-                        var box = new TextBox { Text = value.ToString() };
-                        box.SetBinding(TextBox.TextProperty, binding);
-
-                        valueElement = box;
-                    }
-                    else if (value is float || value is double)
-                    {
-                        var box = new TextBox { Text = value.ToString() };
-                        box.SetBinding(TextBox.TextProperty, binding);
-
-                        valueElement = box;
-                    }
-                    else if (value is byte || value is sbyte)
-                    {
-                        var box = new TextBox { Text = value.ToString() };
-                        box.SetBinding(TextBox.TextProperty, binding);
-
-                        valueElement = box;
-                    }
-                    else if (value is Enum)
-                    {
-                        var box = new ComboBox
-                        {
-                            SelectedValue = value,
-                            ItemsSource = Enum.GetValues(propType)
-                        };
-
-                        box.SetBinding(ComboBox.SelectedItemProperty, binding);
-
-                        valueElement = box;
-                    }
-                    else if (value is IList)
-                    {
-                        var box = new ListBox
-                        {
-                            ItemsSource = (value as IList),
-                        };
-
-                        box.SetBinding(ListBox.SelectedItemProperty, binding);
-
-                        valueElement = box;
-                    }
-                    else if (value is IDictionary)
-                    {
-                        var box = new ListBox
-                        {
-                            ItemsSource = (value as IDictionary),
-                        };
-
-                        box.SetBinding(ListBox.SelectedItemProperty, binding);
-
-                        valueElement = box;
-                    }
-                    else
-                    {
-                        // structs? fuck it...
-                        continue;
-                    }
-
-                    DockPanel.SetDock(label, Dock.Left);
-                    DockPanel.SetDock(valueElement, Dock.Right);
-
-                    element.Children.Add(label);
-                    element.Children.Add(valueElement);
-
-                    stack.Children.Add(element);
-                }
-                else
-                {
-                    var group = new GroupBox
-                    {
-                        Header = prop.Name,
-                        Content = MakeScaffolding(value)
-                    };
-
-                    stack.Children.Add(group);
-
-                    //var label = new Label { Content = prop.Name };
-                    //var list = MakeScaffolding(prop.GetValue(settings));
-
-                    //DockPanel.SetDock(label, Dock.Left);
-                    //DockPanel.SetDock(list, Dock.Right);
-
-                    //element.Children.Add(label);
-                    //element.Children.Add(list);
-
-                    //stack.Children.Add(element);
-                }
-            }
-
-            return stack;
+            foreach (var uiElement in EditorElementGenerator.GenerateUiElementRecursive(Settings))
+                MainStack.Children.Add(uiElement);
         }
     }
 }

--- a/iBot-GUI/Utilities/EditorElementGenerator.cs
+++ b/iBot-GUI/Utilities/EditorElementGenerator.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using iBot_GUI.Annotations;
+using Newtonsoft.Json;
+
+namespace iBot_GUI.Utilities
+{
+    // @TODO: not too happy with the name... needs something more concise yet still telling
+    /// <summary>
+    /// Class that generates a <see cref="UIElement"/> to edit named values.
+    /// </summary>
+    public static class EditorElementGenerator
+    {
+        /// <summary>
+        /// Generate a <see cref="UIElement"/> for a specific <see cref="Type"/>
+        /// </summary>
+        /// <typeparam name="T">Type that determines which <see cref="UIElement"/> will be generated</typeparam>
+        /// <param name="name">Name of this Value</param>
+        /// <param name="value">Value for the desired <see cref="UIElement"/></param>
+        /// <param name="binding">Binding to use while binding the Value to the UIElement</param>
+        /// <returns><see cref="UIElement"/> that can be injected into some other Control</returns>
+        [NotNull]
+        public static UIElement GenerateUiElement<T>(string name, [NotNull] T value, [CanBeNull] Binding binding = null)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            var type = typeof(T);
+
+            var result = HandleValueType(type, value, binding)
+                         ?? (HandleSpecialTypes(type, value, binding)
+                             ?? HandleGenericType(type, value, binding));
+
+            return result;
+        }
+
+        /// <summary>
+        /// Handle the creation of an <see cref="UIElement"/> for some ValueType
+        /// </summary>
+        /// <typeparam name="T">Type that determines which <see cref="UIElement"/> will be generated</typeparam>
+        /// <param name="name">Name of this Value</param>
+        /// <param name="value">Value for the desired <see cref="UIElement"/></param>
+        /// <param name="description">Optional description for this Key / Value Pair</param>
+        /// <param name="binding">Binding to use while binding the Value to the UIElement</param>
+        /// <returns>A valid <see cref="UIElement"/> or null when no UIElement could be created</returns>
+        [CanBeNull]
+        private static UIElement HandleValueType<T>([NotNull] string name,
+                                                    [NotNull] T value,
+                                                    [CanBeNull] string description = null,
+                                                    [CanBeNull] Binding binding = null)
+        {
+            var type = typeof(T);
+
+            var element = new DockPanel();
+
+            Func<UIElement> genericElementCreator = () =>
+            {
+                var box = new TextBox {Text = value.ToString()};
+
+                if (binding != null)
+                    box.SetBinding(TextBox.TextProperty, binding);
+
+                return box;
+            };
+
+            UIElement valueElement;
+
+            if (type == typeof(char) || type == typeof(string))
+            {
+                valueElement = genericElementCreator.Invoke();
+            }
+            else if (type == typeof(bool))
+            {
+                // double cast because direct cast is not currently possible in C# - ugly but it works for now
+                var box = new CheckBox {IsChecked = (bool) (object) value};
+
+                if (binding != null)
+                    box.SetBinding(ToggleButton.IsCheckedProperty, binding);
+
+                valueElement = box;
+            }
+            else if (type == typeof(short)
+                     || type == typeof(int)
+                     || type == typeof(long)
+                     || type == typeof(ushort)
+                     || type == typeof(uint)
+                     || type == typeof(ulong))
+            {
+                valueElement = genericElementCreator.Invoke();
+            }
+            else if (type == typeof(float) || type == typeof(double))
+            {
+                valueElement = genericElementCreator.Invoke();
+            }
+            else if (type == typeof(byte) || type == typeof(sbyte))
+            {
+                valueElement = genericElementCreator.Invoke();
+            }
+            else if (type == typeof(Enum))
+            {
+                var box = new ComboBox
+                {
+                    SelectedValue = value,
+                    ItemsSource = Enum.GetValues(type)
+                };
+
+                if (binding != null)
+                    box.SetBinding(Selector.SelectedItemProperty, binding);
+
+                valueElement = box;
+            }
+            else
+            {
+                // type is not supported in this function
+                return null;
+            }
+
+            var label = new Label
+            {
+                Content = name,
+                ToolTip = description
+            };
+
+            DockPanel.SetDock(label, Dock.Left);
+            DockPanel.SetDock(valueElement, Dock.Right);
+
+            element.Children.Add(label);
+            element.Children.Add(valueElement);
+
+            return element;
+        }
+
+        /// <summary>
+        /// Handle the creation of an <see cref="UIElement"/> for Special Classes
+        /// </summary>
+        /// <typeparam name="T">Type that determines which <see cref="UIElement"/> will be generated</typeparam>
+        /// <param name="name">Name of this Value</param>
+        /// <param name="value">Value for the desired <see cref="UIElement"/></param>
+        /// <param name="description">Optional description for this Key / Value Pair</param>
+        /// <param name="binding">Binding to use while binding the Value to the UIElement</param>
+        /// <returns>A valid <see cref="UIElement"/> or null when no UIElement could be created</returns>
+        [CanBeNull]
+        private static UIElement HandleSpecialTypes<T>([NotNull] string name,
+                                                       [NotNull] T value,
+                                                       [CanBeNull] string description = null,
+                                                       [CanBeNull] Binding binding = null)
+        {
+            var type = typeof(T);
+
+            var element = new DockPanel();
+
+            UIElement valueElement;
+
+            if (typeof(IList).IsAssignableFrom(type))
+            {
+                var box = new ListBox
+                {
+                    ItemsSource = value as IList,
+                };
+
+                if (binding != null)
+                    box.SetBinding(Selector.SelectedItemProperty, binding);
+
+                valueElement = box;
+            }
+            else if (typeof(IDictionary).IsAssignableFrom(type))
+            {
+                var box = new ListBox
+                {
+                    ItemsSource = value as IDictionary,
+                };
+
+                if (binding != null)
+                    box.SetBinding(Selector.SelectedItemProperty, binding);
+
+                valueElement = box;
+            }
+            else
+            {
+                // type is not supported in this function
+                return null;
+            }
+
+            var label = new Label
+            {
+                Content = name,
+                ToolTip = description
+            };
+
+            DockPanel.SetDock(label, Dock.Left);
+            DockPanel.SetDock(valueElement, Dock.Right);
+
+            element.Children.Add(label);
+            element.Children.Add(valueElement);
+
+            return element;
+        }
+
+        /// <summary>
+        /// Handle the creation of an <see cref="UIElement"/> for all Types that are not covered by <see cref="HandleValueType{T}"/> and <see cref="HandleSpecialTypes{T}"/>
+        /// </summary>
+        /// <typeparam name="T">Type that determines which <see cref="UIElement"/> will be generated</typeparam>
+        /// <param name="name">Name of this Value</param>
+        /// <param name="value">Value for the desired <see cref="UIElement"/></param>
+        /// <param name="description">Optional description for this Key / Value Pair</param>
+        /// <param name="binding">Binding to use while binding the Value to the UIElement</param>
+        /// <returns>A valid <see cref="UIElement"/></returns>
+        [NotNull]
+        private static UIElement HandleGenericType<T>([NotNull] string name,
+                                                      [NotNull] T value,
+                                                      [CanBeNull] string description = null,
+                                                      [CanBeNull] Binding binding = null)
+        {
+            var element = new DockPanel();
+
+            var box = new TextBox();
+
+            try
+            {
+                box.Text = JsonConvert.SerializeObject(value, Formatting.Indented);
+            }
+            catch (JsonException)
+            {
+                box.Text = "";
+            }
+
+            if (binding != null)
+                box.SetBinding(TextBox.TextProperty, binding);
+
+            var valueElement = box;
+
+            var label = new Label
+            {
+                Content = name,
+                ToolTip = description
+            };
+
+            DockPanel.SetDock(label, Dock.Left);
+            DockPanel.SetDock(valueElement, Dock.Right);
+
+            element.Children.Add(label);
+            element.Children.Add(valueElement);
+
+            return element;
+        }
+    }
+}

--- a/iBot-GUI/Utilities/EditorElementGenerator.cs
+++ b/iBot-GUI/Utilities/EditorElementGenerator.cs
@@ -169,7 +169,7 @@ namespace iBot_GUI.Utilities
             var label = new Label
             {
                 Content = name,
-                ToolTip = description
+                ToolTip = description ?? ""
             };
 
             DockPanel.SetDock(label, Dock.Left);
@@ -235,7 +235,7 @@ namespace iBot_GUI.Utilities
             var label = new Label
             {
                 Content = name,
-                ToolTip = description
+                ToolTip = description ?? ""
             };
 
             DockPanel.SetDock(label, Dock.Left);
@@ -262,30 +262,22 @@ namespace iBot_GUI.Utilities
                                                       [CanBeNull] string description = null,
                                                       [CanBeNull] Binding binding = null)
         {
-            var element = new DockPanel();
+            var stack = new StackPanel();
+
+            foreach (var uiElement in GenerateUiElementRecursive(value))
+                stack.Children.Add(uiElement);
 
             var box = new GroupBox
             {
                 Header = name,
-                Content = GenerateUiElementRecursive(value)
+                Content = stack,
+                ToolTip = description ?? ""
             };
 
             if (binding != null)
                 box.SetBinding(TextBox.TextProperty, binding);
 
-            var label = new Label
-            {
-                Content = name,
-                ToolTip = description
-            };
-
-            DockPanel.SetDock(label, Dock.Left);
-            DockPanel.SetDock(box, Dock.Right);
-
-            element.Children.Add(label);
-            element.Children.Add(box);
-
-            return element;
+            return box;
         }
     }
 }

--- a/iBot-GUI/iBot-GUI.csproj
+++ b/iBot-GUI/iBot-GUI.csproj
@@ -57,6 +57,9 @@
       <HintPath>..\packages\MaterialDesignThemes.1.5.0.523\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="SQLite.CodeFirst, Version=1.2.0.12, Culture=neutral, PublicKeyToken=eb96ba0a78d831a7, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLite.CodeFirst.1.2.0.12\lib\net45\SQLite.CodeFirst.dll</HintPath>
       <Private>True</Private>
@@ -153,6 +156,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>SettingsDescriptions.resx</DependentUpon>
     </Compile>
+    <Compile Include="Utilities\EditorElementGenerator.cs" />
     <Compile Include="Windows\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/iBot-GUI/iBot-GUI.csproj
+++ b/iBot-GUI/iBot-GUI.csproj
@@ -57,9 +57,6 @@
       <HintPath>..\packages\MaterialDesignThemes.1.5.0.523\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="SQLite.CodeFirst, Version=1.2.0.12, Culture=neutral, PublicKeyToken=eb96ba0a78d831a7, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLite.CodeFirst.1.2.0.12\lib\net45\SQLite.CodeFirst.dll</HintPath>
       <Private>True</Private>

--- a/iBot-GUI/packages.config
+++ b/iBot-GUI/packages.config
@@ -4,7 +4,6 @@
   <package id="EntityFramework" version="6.1.3" targetFramework="net461" />
   <package id="MaterialDesignColors" version="1.1.2" targetFramework="net461" />
   <package id="MaterialDesignThemes" version="1.5.0.523" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="SQLite.CodeFirst" version="1.2.0.12" targetFramework="net461" />
   <package id="System.Data.SQLite" version="1.0.101.0" targetFramework="net461" />
   <package id="System.Data.SQLite.Core" version="1.0.101.0" targetFramework="net461" />

--- a/iBot-GUI/packages.config
+++ b/iBot-GUI/packages.config
@@ -4,6 +4,7 @@
   <package id="EntityFramework" version="6.1.3" targetFramework="net461" />
   <package id="MaterialDesignColors" version="1.1.2" targetFramework="net461" />
   <package id="MaterialDesignThemes" version="1.5.0.523" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="SQLite.CodeFirst" version="1.2.0.12" targetFramework="net461" />
   <package id="System.Data.SQLite" version="1.0.101.0" targetFramework="net461" />
   <package id="System.Data.SQLite.Core" version="1.0.101.0" targetFramework="net461" />


### PR DESCRIPTION
this PR basically moves the `UIElement` generation from the `SettingsControl` code-behind, to a static utility class to de-couple the Control from the sub-control generation.
This should be cleaner and easier to extend in the future.